### PR TITLE
lsプログラムを作成

### DIFF
--- a/05.ls/ls.rb
+++ b/05.ls/ls.rb
@@ -1,15 +1,15 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-def file_or_directory_names
+def current_item
   Dir.glob('*')
 end
 
-def max_file_size(names)
+def max_length_current_item(names)
   names.map(&:size).max
 end
 
-def filenames_with_spaces(names, size)
+def current_item_with_spaces(names, size)
   standard_size = 25
   small_space_size = 2
   big_space_size = 8
@@ -22,7 +22,7 @@ def filenames_with_spaces(names, size)
   end
 end
 
-def divided_filnames(added_blank_files)
+def divided_current_item(added_blank_files)
   divisor_number = 3.0
   turn_number = (added_blank_files.size / divisor_number).ceil
   filenames = []
@@ -30,27 +30,21 @@ def divided_filnames(added_blank_files)
   filenames
 end
 
-def grouped_filenames(split_filenames)
-  if split_filenames[0] && split_filenames[1] && split_filenames[2]
-    split_filenames[0].zip(split_filenames[1], split_filenames[2])
-  elsif split_filenames[1] && split_filenames[2].nil?
-    split_filenames[2] = []
-    split_filenames[2] << split_filenames[1].pop
-    split_filenames[0].zip(split_filenames[1], split_filenames[2])
+def grouped_current_item(split_filenames)
+  max_size = split_filenames.map(&:size).max
+  split_filenames.map do |names|
+    names.size < max_size && (max_size - names.size).times { names.push('') }
   end
+  split_filenames.transpose
 end
 
 def main
-  names = file_or_directory_names
-  size = max_file_size(names)
-  added_spaces_filenames = filenames_with_spaces(names, size)
-  split_filenames = divided_filnames(added_spaces_filenames)
-  processed_filenames = grouped_filenames(split_filenames)
-  if processed_filenames
-    processed_filenames.each { |f| puts f.join }
-  else
-    print split_filenames.join
-  end
+  names = current_item
+  size = max_length_current_item(names)
+  added_spaces_filenames = current_item_with_spaces(names, size)
+  split_filenames = divided_current_item(added_spaces_filenames)
+  processed_filenames = grouped_current_item(split_filenames)
+  processed_filenames.each { |filenames| puts filenames.join }
 end
 
 main

--- a/05.ls/ls.rb
+++ b/05.ls/ls.rb
@@ -1,0 +1,34 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+def file_name
+  current_directory = Dir.entries('.')
+  file_names = []
+  current_directory.each { |f| file_names.push(f) unless f.match?(/^['.']/) }
+  file_names
+end
+
+def file_blank(names)
+  names.map { |name| name.ljust(24) }
+end
+
+def file_divided(names_blank)
+  into_names_blank = names_blank
+  turn_number = (into_names_blank.size / 3.0).ceil
+  file_divide = []
+  into_names_blank.sort.each_slice(turn_number) { |f| file_divide.push(f) }
+  file_divide
+end
+
+def main
+  names = file_name
+  names_blank = file_blank(names)
+  names_divided = file_divided(names_blank)
+  if names_divided[0] && names_divided[1] && names_divided[2]
+    names_divided[0].zip(names_divided[1], names_divided[2]) { |f| puts f.join }
+  else
+    print names_divided.join
+  end
+end
+
+main

--- a/05.ls/ls.rb
+++ b/05.ls/ls.rb
@@ -1,33 +1,55 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-def file_name
-  current_directory = Dir.entries('.')
-  file_names = []
-  current_directory.each { |f| file_names.push(f) unless f.match?(/^['.']/) }
-  file_names
+def file_or_directory_names
+  Dir.glob('*')
 end
 
-def file_blank(names)
-  names.map { |name| name.ljust(24) }
+def max_file_size(names)
+  names.map(&:size).max
 end
 
-def file_divided(names_blank)
-  into_names_blank = names_blank
-  turn_number = (into_names_blank.size / 3.0).ceil
-  file_divide = []
-  into_names_blank.sort.each_slice(turn_number) { |f| file_divide.push(f) }
-  file_divide
+def filenames_with_spaces(names, size)
+  standard_size = 25
+  small_space_size = 2
+  big_space_size = 8
+  names.map do |name|
+    if size >= standard_size
+      name.ljust(size + small_space_size)
+    else
+      name.ljust(size + big_space_size)
+    end
+  end
+end
+
+def divided_filnames(added_blank_files)
+  divisor_number = 3.0
+  turn_number = (added_blank_files.size / divisor_number).ceil
+  filenames = []
+  added_blank_files.sort.each_slice(turn_number) { |names| filenames.push(names) }
+  filenames
+end
+
+def grouped_filenames(split_filenames)
+  if split_filenames[0] && split_filenames[1] && split_filenames[2]
+    split_filenames[0].zip(split_filenames[1], split_filenames[2])
+  elsif split_filenames[1] && split_filenames[2].nil?
+    split_filenames[2] = []
+    split_filenames[2] << split_filenames[1].pop
+    split_filenames[0].zip(split_filenames[1], split_filenames[2])
+  end
 end
 
 def main
-  names = file_name
-  names_blank = file_blank(names)
-  names_divided = file_divided(names_blank)
-  if names_divided[0] && names_divided[1] && names_divided[2]
-    names_divided[0].zip(names_divided[1], names_divided[2]) { |f| puts f.join }
+  names = file_or_directory_names
+  size = max_file_size(names)
+  added_spaces_filenames = filenames_with_spaces(names, size)
+  split_filenames = divided_filnames(added_spaces_filenames)
+  processed_filenames = grouped_filenames(split_filenames)
+  if processed_filenames
+    processed_filenames.each { |f| puts f.join }
   else
-    print names_divided.join
+    print split_filenames.join
   end
 end
 

--- a/05.ls/ls.rb
+++ b/05.ls/ls.rb
@@ -1,15 +1,15 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-def current_item
+def current_items
   Dir.glob('*')
 end
 
-def max_length_current_item(names)
+def current_items_max_length(names)
   names.map(&:size).max
 end
 
-def current_item_with_spaces(names, size)
+def current_items_with_spaces(names, size)
   standard_size = 25
   small_space_size = 2
   big_space_size = 8
@@ -22,7 +22,7 @@ def current_item_with_spaces(names, size)
   end
 end
 
-def divided_current_item(added_blank_files)
+def divided_current_items(added_blank_files)
   divisor_number = 3.0
   turn_number = (added_blank_files.size / divisor_number).ceil
   filenames = []
@@ -30,7 +30,7 @@ def divided_current_item(added_blank_files)
   filenames
 end
 
-def grouped_current_item(split_filenames)
+def grouped_current_items(split_filenames)
   max_size = split_filenames.map(&:size).max
   split_filenames.map do |names|
     names.size < max_size && (max_size - names.size).times { names.push('') }
@@ -39,11 +39,11 @@ def grouped_current_item(split_filenames)
 end
 
 def main
-  names = current_item
-  size = max_length_current_item(names)
-  added_spaces_filenames = current_item_with_spaces(names, size)
-  split_filenames = divided_current_item(added_spaces_filenames)
-  processed_filenames = grouped_current_item(split_filenames)
+  names = current_items
+  size = current_items_max_length(names)
+  added_spaces_filenames = current_items_with_spaces(names, size)
+  split_filenames = divided_current_items(added_spaces_filenames)
+  processed_filenames = grouped_current_items(split_filenames)
   processed_filenames.each { |filenames| puts filenames.join }
 end
 


### PR DESCRIPTION
メソッド名をとても悩みましたが、見直してみました。

動作については、確認していませんでした...。自分の方でも同様に表示が崩れましたので、修正してみました。
ディレクトリ内の要素が4つの場合でも、3列表示を維持
```
❯ ruby ls.rb
1st_content.txt          3rd_content.txt          ls.rb                    
2nd_content.txt              
```
また、要素名が長くても表示が崩れない (ターミナルの幅を最大にした場合)
```
❯ ruby ls.rb
1st_content.txt                                                    3rd_content.txt                                                    ls.rb                                                              
2nd_very_very_long_file_name_in_the_directory.txt4th_content.txt   5th_content.txt                                                    
```


